### PR TITLE
Added support for newer versions of stencil that need to have h be added for JSX support

### DIFF
--- a/component/index.js
+++ b/component/index.js
@@ -9,6 +9,7 @@ module.exports = class extends Generator {
     const stylingSupport =
       this.options.stylingSupport || _.get(prompValues, 'stylingSupport');
     const testSupport = this.options.testSupport || _.get(prompValues, 'testSupport');
+    const jsxSupport = this.options.jsxSupport || _.get(prompValues, 'jsxSupport');
 
     let prompts = [
       {
@@ -27,6 +28,7 @@ module.exports = class extends Generator {
         choices: ['Sass', 'PostCSS']
       });
     }
+
     if (testSupport === undefined) {
       prompts.push({
         type: 'confirm',
@@ -35,9 +37,18 @@ module.exports = class extends Generator {
       });
     }
 
+    if (jsxSupport === undefined) {
+      prompts.push({
+        type: 'confirm',
+        name: 'jsxSupport',
+        message: 'Support JSX?'
+      });
+    }
+
     this.props = _.assign(this.props, {
       stylingSupport: stylingSupport,
-      testSupport: testSupport
+      testSupport: testSupport,
+      jsxSupport: jsxSupport
     });
 
     return this.prompt(prompts).then(props => {

--- a/component/templates/_component.css
+++ b/component/templates/_component.css
@@ -1,2 +1,2 @@
-.<%=paramCaseComponentName%>{
+.<%=paramCaseComponentName%> {
 }

--- a/component/templates/_component.scss
+++ b/component/templates/_component.scss
@@ -1,2 +1,2 @@
-.<%=paramCaseComponentName%>{
+.<%=paramCaseComponentName%> {
 }

--- a/component/templates/_component.spec.ts
+++ b/component/templates/_component.spec.ts
@@ -1,5 +1,5 @@
 import { render } from '@stencil/core/testing';
-import { <%=componentName%> } from './<%=paramCaseComponentName%>';
+import { <%=componentName%><% if (jsxSupport) { %>, h<% } %> } from './<%=paramCaseComponentName%>';
 
 describe('<%=paramCaseComponentName%>', () => {
   it('should build', () => {

--- a/component/templates/_component.tsx
+++ b/component/templates/_component.tsx
@@ -1,4 +1,4 @@
-import { Component } from '@stencil/core';
+import { Component<% if (jsxSupport) { %>, h<% } %> } from '@stencil/core';
 
 @Component({
   tag: '<%= paramCaseComponentName %>',


### PR DESCRIPTION
Here is a PR to add jsx support for file generation, stencil now requires in the newer versions that h be imported from stencil core.